### PR TITLE
Workaround for Mexico 1931 issue

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -12,5 +12,6 @@ pushd ./input
 wget https://www.iana.org/time-zones/repository/releases/tzdata$1.tar.gz
 pushd ./tzdata-latest
 tar -xvf ../tzdata$1.tar.gz
+sed -i -e 's/^\(Rule[\t ]*[^\t ]*[\t ]*[^\t ]*[\t ]*[^\t ]*[\t ]*[^\t ]*[\t ]*...\)[^\t ]*/\1/' *
 popd
 popd


### PR DESCRIPTION
Automatically trim months to the first three letters during the download phase, working around the uncommon formatting in the 2024b database until a permanent solution can be implemented.

Background for other users of this library:  tzdata 2024b includes a reference to "April", but many libraries only handle the abbreviated "Apr".  [The maintainers of this library have reported the issue](https://lists.iana.org/hyperkitty/list/tz@iana.org/thread/JG5U73FDN3DH2OM4TUGHMMNX3LOD4MHF/), as have [many others](https://lists.iana.org/hyperkitty/list/tz@iana.org/latest).  This instance will be fixed in a future release, but "April" is specifically allowed by the standard.

This change has broken an app I maintain, so a temporary fix like this would be much appreciated :)