### PR TITLE
Add version to main "tzdata" package

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -67,6 +67,7 @@ const zonePaths = zoneFiles.map((file) => {
 console.log("generating data for all zones")
 const zoneData = {};
 zoneData["tzdata"] = parse(zonePaths);
+zoneData["tzdata"].version = tzVersion;
 
 // generate json data per input file
 zonePaths.forEach((zonePath, index) => {


### PR DESCRIPTION
Adds the current IANA tz database version (i.e. `"version": "2025b"`) to the main "tzdata" package (`dist\tzdata`). I noticed this was in the individual region packages but not the main one.